### PR TITLE
Refactor Inline Text Formatting Using Base Command Class

### DIFF
--- a/TextEditor/Models/Commands/BoldTextCommand.cs
+++ b/TextEditor/Models/Commands/BoldTextCommand.cs
@@ -2,30 +2,11 @@
 
 namespace TextEditor.Models.Commands
 {
-    public class BoldTextCommand : Command
+    public class BoldTextCommand : InlineFormattingCommand
     {
-        private int start, length;
-
-        public BoldTextCommand(TextBox editText, Document document) : base(editText, document) 
+        public BoldTextCommand(TextBox editText, Document document)
+            : base(editText, document, "**", "**")
         {
-            start = _editTextBox.SelectionStart;
-            length = _editTextBox.SelectionLength;
-        }
-
-        public override void Execute()
-        {
-            _document.InsertText("**", start + length);
-            _document.InsertText("**", start);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start + length + 2;        
-        }
-
-        public override void Undo()
-        {
-            _document.DeleteText(start + length + 2, 2);
-            _document.DeleteText(start, 2);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start;
         }
     }
 }

--- a/TextEditor/Models/Commands/InlineFormattingCommand.cs
+++ b/TextEditor/Models/Commands/InlineFormattingCommand.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TextEditor.Models.Commands
+{
+    public abstract class InlineFormattingCommand : Command
+    {
+        protected readonly string _openTag;
+        protected readonly string _closeTag;
+        protected int _start;
+        protected int _length;
+
+        public InlineFormattingCommand(TextBox editText, Document document, string openTag, string closeTag)
+            : base(editText, document)
+        {
+            _openTag = openTag;
+            _closeTag = closeTag;
+            _start = _editTextBox.SelectionStart;
+            _length = _editTextBox.SelectionLength;
+        }
+
+        public override void Execute()
+        {
+            _document.InsertText(_closeTag, _start + _length);
+            _document.InsertText(_openTag, _start);
+            UpdateTextBox(_start + _length + _openTag.Length + _closeTag.Length);
+        }
+
+        public override void Undo()
+        {
+            _document.DeleteText(_start + _length + _closeTag.Length, _closeTag.Length);
+            _document.DeleteText(_start, _openTag.Length);
+            UpdateTextBox(_start);
+        }
+
+        protected void UpdateTextBox(int caretPosition)
+        {
+            _editTextBox.Text = _document.Content;
+            _editTextBox.CaretIndex = caretPosition;
+        }
+    }
+}

--- a/TextEditor/Models/Commands/ItalicTextCommand.cs
+++ b/TextEditor/Models/Commands/ItalicTextCommand.cs
@@ -2,30 +2,11 @@
 
 namespace TextEditor.Models.Commands
 {
-    public class ItalicTextCommand : Command
+    public class ItalicTextCommand : InlineFormattingCommand
     {
-        private int start, length;
-
-        public ItalicTextCommand(TextBox editText, Document document) : base(editText, document)
+        public ItalicTextCommand(TextBox editText, Document document)
+            : base(editText, document, "*", "*")
         {
-            start = _editTextBox.SelectionStart;
-            length = _editTextBox.SelectionLength;
-        }
-
-        public override void Execute()
-        {
-            _document.InsertText("*", start + length);
-            _document.InsertText("*", start);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start + length + 1;
-        }
-
-        public override void Undo()
-        {
-            _document.DeleteText(start + length + 1, 1);
-            _document.DeleteText(start, 1);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start;
         }
     }
 }


### PR DESCRIPTION
**Problem**
Both BoldTextCommand and ItalicTextCommand contain duplicated logic for inserting formatting symbols around selected text and updating the TextBox. This duplication increases the risk of inconsistencies and makes the code harder to maintain or extend with new formatting styles.

**Proposed Solution**
I extracted the common behavior into a new abstract base class InlineFormattingCommand. It handles inserting open/close tags, updating the TextBox content and caret position, and implements Execute and Undo in a reusable way.

BoldTextCommand and ItalicTextCommand now simply pass the appropriate formatting symbols (** and *) to the base class.

**Benefits**
- Eliminates duplicated code
- Easier to extend (e.g., underline, strikethrough, quote formatting)
- Improved readability and maintainability
- Adheres to the Open/Closed principle