### PR TITLE
Eliminate duplication in text formatting commands using Template Meth…

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/TextEditor.iml
+++ b/.idea/TextEditor.iml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <excludeFolder url="file://$MODULE_DIR$/.tmp" />
+      <excludeFolder url="file://$MODULE_DIR$/temp" />
+      <excludeFolder url="file://$MODULE_DIR$/tmp" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/TextEditor.iml" filepath="$PROJECT_DIR$/.idea/TextEditor.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="" vcs="Git" />
+  </component>
+</project>

--- a/TextEditor/Models/Commands/BoldTextCommand.cs
+++ b/TextEditor/Models/Commands/BoldTextCommand.cs
@@ -1,31 +1,12 @@
-﻿using System.Windows.Controls;
+using System.Windows.Controls;
 
 namespace TextEditor.Models.Commands
 {
-    public class BoldTextCommand : Command
-    {
-        private int start, length;
-
-        public BoldTextCommand(TextBox editText, Document document) : base(editText, document) 
-        {
-            start = _editTextBox.SelectionStart;
-            length = _editTextBox.SelectionLength;
-        }
-
-        public override void Execute()
-        {
-            _document.InsertText("**", start + length);
-            _document.InsertText("**", start);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start + length + 2;        
-        }
-
-        public override void Undo()
-        {
-            _document.DeleteText(start + length + 2, 2);
-            _document.DeleteText(start, 2);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start;
-        }
-    }
+  public class BoldTextCommand : FormattedTextCommand
+  {
+    protected override string OpeningTag => "**";
+    protected override string ClosingTag => "**";
+    public BoldTextCommand(TextBox editText, Document document)
+        : base(editText, document) { }
+  }
 }

--- a/TextEditor/Models/Commands/FormattedTextCommand.cs
+++ b/TextEditor/Models/Commands/FormattedTextCommand.cs
@@ -1,0 +1,54 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Controls;
+
+namespace TextEditor.Models.Commands
+{
+  public abstract class FormattedTextCommand : Command
+  {
+    protected int start, length;
+
+    protected abstract string OpeningTag { get; }
+    protected abstract string ClosingTag { get; }
+
+    public FormattedTextCommand(TextBox editText, Document document)
+        : base(editText, document)
+    {
+      start = _editTextBox.SelectionStart;
+      length = _editTextBox.SelectionLength;
+    }
+
+    public override void Execute()
+    {
+      InsertTags();
+      UpdateEditor();
+    }
+
+    public override void Undo()
+    {
+      RemoveTags();
+      UpdateEditor();
+    }
+
+    private void InsertTags()
+    {
+      _document.InsertText(ClosingTag, start + length);
+      _document.InsertText(OpeningTag, start);
+    }
+
+    private void RemoveTags()
+    {
+      _document.DeleteText(start + length + ClosingTag.Length, ClosingTag.Length);
+      _document.DeleteText(start, OpeningTag.Length);
+    }
+
+    private void UpdateEditor()
+    {
+      _editTextBox.Text = _document.Content;
+      _editTextBox.CaretIndex = start + length + OpeningTag.Length + ClosingTag.Length;
+    }
+  }
+}

--- a/TextEditor/Models/Commands/ItalicTextCommand.cs
+++ b/TextEditor/Models/Commands/ItalicTextCommand.cs
@@ -1,31 +1,12 @@
-﻿using System.Windows.Controls;
+using System.Windows.Controls;
 
 namespace TextEditor.Models.Commands
 {
-    public class ItalicTextCommand : Command
-    {
-        private int start, length;
-
-        public ItalicTextCommand(TextBox editText, Document document) : base(editText, document)
-        {
-            start = _editTextBox.SelectionStart;
-            length = _editTextBox.SelectionLength;
-        }
-
-        public override void Execute()
-        {
-            _document.InsertText("*", start + length);
-            _document.InsertText("*", start);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start + length + 1;
-        }
-
-        public override void Undo()
-        {
-            _document.DeleteText(start + length + 1, 1);
-            _document.DeleteText(start, 1);
-            _editTextBox.Text = _document.Content;
-            _editTextBox.CaretIndex = start;
-        }
-    }
+  public class ItalicTextCommand : FormattedTextCommand
+  {
+    protected override string OpeningTag => "*";
+    protected override string ClosingTag => "*";
+    public ItalicTextCommand(TextBox editText, Document document)
+        : base(editText, document) { }
+  }
 }


### PR DESCRIPTION
Опис проблеми:

- У класах BoldTextCommand та ItalicTextCommand присутній значний дубльований код для форматування тексту, що:

- Порушує принцип DRY (Don't Repeat Yourself) – ідентична логіка вставки/видалення тегів

- Ускладнює підтримку – будь-які зміни у логіці форматування вимагають правок у кількох класах

- Збільшує ймовірність помилок – можна ненавмисно змінити логіку лише в одній команді

Пропоноване вирішення:

Застосувати патерн Template Method:

- Створити абстрактний базовий клас FormattedTextCommand

- Винести спільну логіку в базовий клас

Переваги змін:
✅ Усунено дублювання коду – спільна логіка в базовому класі

Вплив на існуючий код:
Не змінює зовнішню поведінку – функціонал працює як раніше

Зворотня сумісність – зовнішній інтерфейс класів залишився незмінним

Мінімальний ризик – зміни торкаються лише внутрішньої реалізації