### PR TITLE
Refactored MarkdownParser using Interpreter pattern

### DIFF
--- a/TextEditor/Models/Parser/Interpreter/BoldElement.cs
+++ b/TextEditor/Models/Parser/Interpreter/BoldElement.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.RegularExpressions;
+using System.Windows.Documents;
+
+namespace TextEditor.Models.Parser.Interpreter
+{
+    public class BoldElement : MarkdownElementBase
+    {
+        public BoldElement() : base(@"^\*\*(.+?)\*\*") { }
+
+        public override Inline? Parse(string text, ref int position)
+        {
+            if (TryMatch(text, position, out var match))
+            {
+                position += match.Index + match.Length;
+                return new Bold(new Run(match.Groups[1].Value));
+            }
+            return null;
+        }
+    }
+}

--- a/TextEditor/Models/Parser/Interpreter/BoldItalicElement.cs
+++ b/TextEditor/Models/Parser/Interpreter/BoldItalicElement.cs
@@ -1,0 +1,25 @@
+﻿using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Documents;
+
+namespace TextEditor.Models.Parser.Interpreter
+{
+    public class BoldItalicElement : MarkdownElementBase
+    {
+        public BoldItalicElement() : base(@"^\*\*\*(.+?)\*\*\*") { }
+
+        public override Inline? Parse(string text, ref int position)
+        {
+            if (TryMatch(text, position, out var match))
+            {
+                position += match.Index + match.Length;
+                return new Run(match.Groups[1].Value)
+                {
+                    FontWeight = FontWeights.Bold,
+                    FontStyle = FontStyles.Italic
+                };
+            }
+            return null;
+        }
+    }
+}

--- a/TextEditor/Models/Parser/Interpreter/IMarkdownElement.cs
+++ b/TextEditor/Models/Parser/Interpreter/IMarkdownElement.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+namespace TextEditor.Models.Parser.Interpreter
+{
+    public interface IMarkdownElement
+    {
+        Inline? Parse(string text, ref int currentPosition);
+    }
+}

--- a/TextEditor/Models/Parser/Interpreter/ItalicElement.cs
+++ b/TextEditor/Models/Parser/Interpreter/ItalicElement.cs
@@ -1,0 +1,20 @@
+﻿using System.Text.RegularExpressions;
+using System.Windows.Documents;
+
+namespace TextEditor.Models.Parser.Interpreter
+{
+    public class ItalicElement : MarkdownElementBase
+    {
+        public ItalicElement() : base(@"^(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)") { }
+
+        public override Inline? Parse(string text, ref int position)
+        {
+            if (TryMatch(text, position, out var match))
+            {
+                position += match.Index + match.Length;
+                return new Italic(new Run(match.Groups[1].Value));
+            }
+            return null;
+        }
+    }
+}

--- a/TextEditor/Models/Parser/Interpreter/MarkdownElementBase.cs
+++ b/TextEditor/Models/Parser/Interpreter/MarkdownElementBase.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+namespace TextEditor.Models.Parser.Interpreter
+{
+    public abstract class MarkdownElementBase : IMarkdownElement
+    {
+        protected readonly string Pattern;
+
+        protected MarkdownElementBase(string pattern)
+        {
+            Pattern = pattern;
+        }
+
+        public abstract Inline? Parse(string text, ref int position);
+
+        protected bool TryMatch(string text, int position, out Match match)
+        {
+            if (position >= text.Length)
+            {
+                match = Match.Empty;
+                return false;
+            }
+
+            match = Regex.Match(text.Substring(position), Pattern);
+            return match.Success;
+        }
+    }
+}


### PR DESCRIPTION
### **Problem**
The [MarkdownParser](https://github.com/DeLinev/TextEditor/blob/main/TextEditor/Models/Parser/MarkdownParser.cs#L9-L14) class had several maintainability issues:

- **Long method smell** – the method ParseInlineMarkdown was long and contained deeply nested logic.
- **Code duplication** – similar regex matching logic was repeated for different markdown styles.
- **Low cohesion** – parsing logic for bold, italic, and bold-italic was all centralized, violating the Single Responsibility Principle.
- **Hard to extend** – adding new inline markdown elements (e.g., underline, code, strikethrough) required editing a large block of code.

### **Solution**
Refactored ParseInlineMarkdown using the Interpreter design pattern:

- Created an interface [IMarkdownElement](https://github.com/sofia-maidaniuk/TextEditor/blob/refactor/markdown-parser-interpreter/TextEditor/Models/Parser/Interpreter/IMarkdownElement.cs) to represent each inline markdown element.
- Introduced a base abstract class [MarkdownElementBase](https://github.com/sofia-maidaniuk/TextEditor/blob/refactor/markdown-parser-interpreter/TextEditor/Models/Parser/Interpreter/MarkdownElementBase.cs) that encapsulates common regex matching logic.
- Implemented concrete classes: `BoldElement`, `ItalicElement`, `BoldItalicElement`
- Replaced the monolithic loop in ParseInlineMarkdown with a clean iteration over the _inlineElements list.

### **Benefits**

- **Improved modularity** – each inline element is handled by its own class.
- **Open/Closed Principle** – new elements can be added without modifying core logic.
- **Simplified method** – ParseInlineMarkdown was reduced.
- **Better testability** – each parser class can be tested independently.
- **Cleaner separation of concerns** – parsing logic is now decoupled from markdown processing.