### PR TITLE
Refactor MarkdownParser: extract BlockParser, InlineParser, and DocumentBuilder

### DIFF
--- a/TextEditor/Models/Parser/BlockParser.cs
+++ b/TextEditor/Models/Parser/BlockParser.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using System.Windows;
+
+namespace TextEditor.Models.Parser
+{
+    public class BlockParser
+    {
+        private const string HeaderPattern = @"^(#{1,6})\s+(.+)$";
+        private const string ListSymbol = "- ";
+        private const int HeaderBaseSize = 26;
+
+        private readonly InlineParser _inlineParser;
+
+        public BlockParser(InlineParser inlineParser)
+        {
+            _inlineParser = inlineParser;
+        }
+
+        public IEnumerable<Block> ParseBlocks(string[] lines)
+        {
+            var blocks = new List<Block>();
+            int lineIndex = 0;
+
+            while (lineIndex < lines.Length)
+            {
+                string line = lines[lineIndex];
+                Block? block = null;
+
+                if (TryParseHeader(line, out block))
+                {
+                    lineIndex++;
+                }
+                else if (TryParseList(lines, ref lineIndex, out block)) { }
+                else if (TryParseParagraph(lines, ref lineIndex, out block)) { }
+                else
+                {
+                    lineIndex++;
+                }
+
+                if (block != null)
+                {
+                    blocks.Add(block);
+                }
+            }
+
+            return blocks;
+        }
+
+        private bool TryParseHeader(string line, out Block? block)
+        {
+            var headerMatch = Regex.Match(line, HeaderPattern);
+            if (headerMatch.Success)
+            {
+                block = CreateHeaderBlock(headerMatch);
+                return true;
+            }
+
+            block = null;
+            return false;
+        }
+
+        private bool TryParseList(string[] lines, ref int lineIndex, out Block? block)
+        {
+            if (lines[lineIndex].TrimStart().StartsWith(ListSymbol))
+            {
+                var list = new List();
+
+                while (lineIndex < lines.Length && lines[lineIndex].TrimStart().StartsWith(ListSymbol))
+                {
+                    list.ListItems.Add(CreateListItem(lines[lineIndex]));
+                    lineIndex++;
+                }
+
+                block = list;
+                return true;
+            }
+
+            block = null;
+            return false;
+        }
+
+        private bool TryParseParagraph(string[] lines, ref int lineIndex, out Block? block)
+        {
+            var paragraphLines = new List<string>();
+
+            while (lineIndex < lines.Length && IsSimpleText(lines[lineIndex]))
+            {
+                paragraphLines.Add(lines[lineIndex]);
+                lineIndex++;
+            }
+
+            if (paragraphLines.Count > 0)
+            {
+                block = CreateParagraphBlock(paragraphLines);
+                return true;
+            }
+
+            block = null;
+            return false;
+        }
+
+        private Paragraph CreateHeaderBlock(Match headerMatch)
+        {
+            int headerLevel = headerMatch.Groups[1].Length;
+            string headerText = headerMatch.Groups[2].Value;
+
+            var header = new Paragraph
+            {
+                FontWeight = FontWeights.Bold,
+                FontSize = HeaderBaseSize - (headerLevel * 2),
+                Margin = new Thickness(0, 10, 0, 5)
+            };
+
+            foreach (var inline in _inlineParser.Parse(headerText))
+            {
+                header.Inlines.Add(inline);
+            }
+
+            return header;
+        }
+
+        private ListItem CreateListItem(string line)
+        {
+            string listItemText = line.TrimStart().Substring(2);
+            var paragraph = CreateParagraphBlock(new[] { listItemText });
+            return new ListItem(paragraph);
+        }
+
+        private Paragraph CreateParagraphBlock(IEnumerable<string> lines)
+        {
+            var paragraph = new Paragraph();
+            string paragraphText = string.Join(" ", lines);
+
+            foreach (var inline in _inlineParser.Parse(paragraphText))
+            {
+                paragraph.Inlines.Add(inline);
+            }
+
+            return paragraph;
+        }
+
+        private bool IsSimpleText(string text)
+        {
+            return !string.IsNullOrWhiteSpace(text) &&
+                   !Regex.IsMatch(text, @"^#{1,6}\s+") &&
+                   !text.TrimStart().StartsWith(ListSymbol);
+        }
+    }
+}

--- a/TextEditor/Models/Parser/InlineParser.cs
+++ b/TextEditor/Models/Parser/InlineParser.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+using TextEditor.Models.Parser.Interpreter;
+
+namespace TextEditor.Models.Parser
+{
+    public class InlineParser
+    {
+        private readonly List<IMarkdownElement> _inlineElements;
+
+        public InlineParser()
+        {
+            _inlineElements = new List<IMarkdownElement>
+            {
+                new BoldItalicElement(),
+                new BoldElement(),
+                new ItalicElement()
+            };
+        }
+
+        public List<Inline> Parse(string text)
+        {
+            var inlines = new List<Inline>();
+            int currentPosition = 0;
+
+            while (currentPosition < text.Length)
+            {
+                bool matched = false;
+
+                foreach (var element in _inlineElements)
+                {
+                    var inline = element.Parse(text, ref currentPosition);
+                    if (inline != null)
+                    {
+                        inlines.Add(inline);
+                        matched = true;
+                        break;
+                    }
+                }
+
+                if (!matched)
+                {
+                    inlines.Add(new Run(text[currentPosition].ToString()));
+                    currentPosition++;
+                }
+            }
+
+            return inlines;
+        }
+    }
+}

--- a/TextEditor/Models/Parser/MarkdownDocumentBuilder.cs
+++ b/TextEditor/Models/Parser/MarkdownDocumentBuilder.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Documents;
+
+namespace TextEditor.Models.Parser
+{
+    public class MarkdownDocumentBuilder
+    {
+        private readonly BlockParser _blockParser;
+
+        public MarkdownDocumentBuilder(BlockParser blockParser)
+        {
+            _blockParser = blockParser;
+        }
+
+        public FlowDocument Build(string markdownText)
+        {
+            if (string.IsNullOrEmpty(markdownText))
+                return new FlowDocument();
+
+            var lines = markdownText.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
+            var blocks = _blockParser.ParseBlocks(lines);
+
+            var document = new FlowDocument();
+            foreach (var block in blocks)
+            {
+                document.Blocks.Add(block);
+            }
+
+            return document;
+        }
+    }
+
+}

--- a/TextEditor/Models/Parser/MarkdownParser.cs
+++ b/TextEditor/Models/Parser/MarkdownParser.cs
@@ -7,197 +7,20 @@ namespace TextEditor.Models.Parser
 {
     public class MarkdownParser
     {
-        private const string HeaderPattern = @"^(#{1,6})\s+(.+)$";
-        private const string ListSymbol = "- ";
-        private const int HeaderBaseSize = 26;
-
-        private readonly List<IMarkdownElement> _inlineElements;
+        private readonly MarkdownDocumentBuilder _builder;
 
         public MarkdownParser()
         {
-            _inlineElements = new List<IMarkdownElement>
-            {
-                new BoldItalicElement(),
-                new BoldElement(),
-                new ItalicElement()
-            };
+            var inlineParser = new InlineParser();
+            var blockParser = new BlockParser(inlineParser);
+            _builder = new MarkdownDocumentBuilder(blockParser);
         }
 
         public FlowDocument Parse(string markdownText)
         {
-            if (string.IsNullOrEmpty(markdownText))
-                return new FlowDocument();
-
-            var document = new FlowDocument();
-            var lines = markdownText.Split(new[] { "\r\n", "\r", "\n" }, StringSplitOptions.None);
-            var blocks = ParseBlocks(lines);
-
-            foreach (var block in blocks)
-            {
-                document.Blocks.Add(block);
-            }
-
-            return document;
-        }
-
-        private IEnumerable<Block> ParseBlocks(string[] lines)
-        {
-            var blocks = new List<Block>();
-            int lineIndex = 0;
-
-            while (lineIndex < lines.Length)
-            {
-                string line = lines[lineIndex];
-                Block? block = null;
-
-                if (TryParseHeader(line, out block))
-                {
-                    lineIndex++;
-                }
-                else if (TryParseList(lines, ref lineIndex, out block)) { }
-                else if (TryParseParagraph(lines, ref lineIndex, out block)) { }
-                else
-                {
-                    lineIndex++;
-                }
-
-                if (block != null)
-                {
-                    blocks.Add(block);
-                }
-            }
-
-            return blocks;
-        }
-
-        private bool TryParseHeader(string line, out Block? block)
-        {
-            var headerMatch = Regex.Match(line, HeaderPattern);
-            if (headerMatch.Success)
-            {
-                block = CreateHeaderBlock(headerMatch);
-                return true;
-            }
-
-            block = null;
-            return false;
-        }
-
-        private bool TryParseList(string[] lines, ref int lineIndex, out Block? block)
-        {
-            if (lines[lineIndex].TrimStart().StartsWith(ListSymbol))
-            {
-                var list = new List();
-
-                while (lineIndex < lines.Length && lines[lineIndex].TrimStart().StartsWith(ListSymbol))
-                {
-                    list.ListItems.Add(CreateListItem(lines[lineIndex]));
-                    lineIndex++;
-                }
-
-                block = list;
-                return true;
-            }
-
-            block = null;
-            return false;
-        }
-
-        private bool TryParseParagraph(string[] lines, ref int lineIndex, out Block? block)
-        {
-            var paragraphLines = new List<string>();
-
-            while (lineIndex < lines.Length && IsSimpleText(lines[lineIndex]))
-            {
-                paragraphLines.Add(lines[lineIndex]);
-                lineIndex++;
-            }
-
-            if (paragraphLines.Count > 0)
-            {
-                block = CreateParagraphBlock(paragraphLines);
-                return true;
-            }
-
-            block = null;
-            return false;
-        }
-
-        private Paragraph CreateHeaderBlock(Match headerMatch)
-        {
-            int headerLevel = headerMatch.Groups[1].Length;
-            string headerText = headerMatch.Groups[2].Value;
-
-            var header = new Paragraph
-            {
-                FontWeight = FontWeights.Bold,
-                FontSize = HeaderBaseSize - (headerLevel * 2),
-                Margin = new Thickness(0, 10, 0, 5)
-            };
-
-            foreach (var inline in ParseInlineMarkdown(headerText))
-            {
-                header.Inlines.Add(inline);
-            }
-
-            return header;
-        }
-
-        private ListItem CreateListItem(string line)
-        {
-            string listItemText = line.TrimStart().Substring(2);
-            var paragraph = CreateParagraphBlock(new[] { listItemText });
-            return new ListItem(paragraph);
-        }
-
-        private Paragraph CreateParagraphBlock(IEnumerable<string> lines)
-        {
-            var paragraph = new Paragraph();
-            string paragraphText = string.Join(" ", lines);
-
-            foreach (var inline in ParseInlineMarkdown(paragraphText))
-            {
-                paragraph.Inlines.Add(inline);
-            }
-
-            return paragraph;
-        }
-
-        private List<Inline> ParseInlineMarkdown(string text)
-        {
-            var inlines = new List<Inline>();
-            int currentPosition = 0;
-
-            while (currentPosition < text.Length)
-            {
-                bool matched = false;
-
-                foreach (var element in _inlineElements)
-                {
-                    var inline = element.Parse(text, ref currentPosition);
-                    if (inline != null)
-                    {
-                        inlines.Add(inline);
-                        matched = true;
-                        break;
-                    }
-                }
-
-                if (!matched)
-                {
-                    inlines.Add(new Run(text[currentPosition].ToString()));
-                    currentPosition++;
-                }
-            }
-
-            return inlines;
-        }
-
-        private bool IsSimpleText(string text)
-        {
-            return !string.IsNullOrWhiteSpace(text) &&
-                   !Regex.IsMatch(text, @"^#{1,6}\s+") &&
-                   !text.TrimStart().StartsWith(ListSymbol);
+            return _builder.Build(markdownText);
         }
     }
+
+
 }


### PR DESCRIPTION
Рефакторинг MarkdownParser: розділення відповідальностей

Опис:
Цей PR виконує масштабний рефакторинг MarkdownParser з метою покращення підтримуваності, читабельності та тестованості.

Основні зміни:
Виділено класи:
InlineParser — для обробки inline markdown (жирний, курсив, жирний+курсив).
BlockParser — парсинг заголовків, списків, абзаців.
MarkdownDocumentBuilder — будує FlowDocument на основі блоків.
MarkdownParser тепер є фасадом, який делегує роботу сервісам.
Прибрана надмірна відповідальність із початкового класу