### PR TITLE
Independent SaveFile logick

### DIFF
--- a/TextEditor/Models/FileManager/FileSaveService.cs
+++ b/TextEditor/Models/FileManager/FileSaveService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TextEditor.Models.FileManager
+{
+    internal class FileSaveService
+    {
+    }
+}

--- a/TextEditor/Models/FileManager/FileSaveService.cs
+++ b/TextEditor/Models/FileManager/FileSaveService.cs
@@ -1,12 +1,72 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using Microsoft.Win32;
+using System.Windows.Documents;
 
 namespace TextEditor.Models.FileManager
 {
-    internal class FileSaveService
+    public enum SaveFileType
     {
+        Markdown,
+        Pdf
+    }
+
+    public class FileSaveResult
+    {
+        public bool Success { get; set; }
+        public string? FilePath { get; set; }
+        public string? FileName { get; set; }
+        public string? ErrorMessage { get; set; }
+    }
+
+    public static class FileSaveService
+    {
+        public static async Task<FileSaveResult> SaveFileAsync(
+            SaveFileType fileType,
+            string content,
+            FlowDocument? flowDocument = null,
+            string? defaultFileName = null)
+        {
+            var fileManager = new FileManager();
+            SaveFileDialog saveFileDialog = new SaveFileDialog();
+
+            switch (fileType)
+            {
+                case SaveFileType.Markdown:
+                    saveFileDialog.Filter = FileManager.FileFilter;
+                    saveFileDialog.DefaultExt = ".md";
+                    break;
+                case SaveFileType.Pdf:
+                    saveFileDialog.Filter = "PDF Files (*.pdf)|*.pdf";
+                    saveFileDialog.DefaultExt = ".pdf";
+                    fileManager.SetSaveStrategy(new PdfSaveStrategy());
+                    break;
+            }
+
+            saveFileDialog.FileName = defaultFileName ?? "Untitled";
+
+            bool? result = saveFileDialog.ShowDialog();
+            if (result == true)
+            {
+                string filePath = saveFileDialog.FileName;
+                bool isSaved = await fileManager.Save(filePath, content, flowDocument);
+                if (isSaved)
+                {
+                    return new FileSaveResult
+                    {
+                        Success = true,
+                        FilePath = filePath,
+                        FileName = saveFileDialog.SafeFileName
+                    };
+                }
+                else
+                {
+                    return new FileSaveResult
+                    {
+                        Success = false,
+                        ErrorMessage = "Failed to save the file."
+                    };
+                }
+            }
+            return new FileSaveResult { Success = false };
+        }
     }
 }


### PR DESCRIPTION
### Refactoring duplicated file saving logic in EditUserControl and PreviewUserControl

## Issue:
Both [EditUserControl](https://github.com/DeLinev/TextEditor/blob/3fb81e5cca23f371ae636c8c5e3bbd0b678c1abc/TextEditor/UserControls/EditUserControl.xaml.cs#L146-L203) and [PreviewUserControl](https://github.com/DeLinev/TextEditor/blob/3fb81e5cca23f371ae636c8c5e3bbd0b678c1abc/TextEditor/UserControls/PreviewUserControl.xaml.cs#L46-L100) contained almost identical code for saving documents as Markdown and PDF files. This duplication violates the DRY (Don't Repeat Yourself) principle and makes future maintenance and extension harder.

## Solution:
Extract the common file saving logic into a dedicated service. The new FileSaveService class will encapsulate all the logic for showing the save dialog, selecting the appropriate save strategy, and handling the result. Both user controls will delegate file saving to this service, reducing code duplication and improving maintainability.

## Changes:
1. Created [FileSaveService](https://github.com/Shadocl-low/TextEditor/blob/0ef5ac4959039cccbb9d1c9c3574a5ee027aaedd/TextEditor/Models/FileManager/FileSaveService.cs) with a unified async method for saving files in different formats (Markdown, PDF).
2. Replaced the duplicated SaveBtn_Click and SaveAsPdfBtn_Click methods in both [EditUserControl](https://github.com/Shadocl-low/TextEditor/blob/0ef5ac4959039cccbb9d1c9c3574a5ee027aaedd/TextEditor/UserControls/EditUserControl.xaml.cs#L146-L192) and [PreviewUserControl](https://github.com/Shadocl-low/TextEditor/blob/0ef5ac4959039cccbb9d1c9c3574a5ee027aaedd/TextEditor/UserControls/PreviewUserControl.xaml.cs#L46-L91) to use the new service.
3. The user controls now only handle user notifications and event propagation, while all file dialog and saving logic is handled by the service.